### PR TITLE
Prefix placeholders with "E.g."

### DIFF
--- a/components/forms/FindMultisigForm.js
+++ b/components/forms/FindMultisigForm.js
@@ -44,7 +44,7 @@ class FindMultisigForm extends React.Component {
             value={this.state.address}
             label="Multisig Address"
             name="address"
-            placeholder={exampleAddress()}
+            placeholder={`E.g. ${exampleAddress()}`}
           />
           <Button label="Use this Multisig" onClick={() => this.handleSearch()} primary />
         </StackableContainer>

--- a/components/forms/MultisigForm.js
+++ b/components/forms/MultisigForm.js
@@ -146,9 +146,9 @@ class MultiSigForm extends React.Component {
                     label={pubkeyGroup.isPubkey ? "Public Key (Secp256k1)" : "Address"}
                     name={pubkeyGroup.isPubkey ? "compressedPubkey" : "address"}
                     width="100%"
-                    placeholder={
+                    placeholder={`E.g. ${
                       pubkeyGroup.isPubkey ? examplePubkey(index) : exampleAddress(index)
-                    }
+                    }`}
                     error={pubkeyGroup.keyError}
                     onBlur={(e) => {
                       this.handleKeyBlur(index, e);

--- a/components/forms/TransactionForm.js
+++ b/components/forms/TransactionForm.js
@@ -92,7 +92,7 @@ class TransactionForm extends React.Component {
             value={this.state.toAddress}
             onChange={(e) => this.handleChange(e)}
             error={this.state.addressError}
-            placeholder={exampleAddress()}
+            placeholder={`E.g. ${exampleAddress()}`}
           />
         </div>
         <div className="form-item">


### PR DESCRIPTION
During testing we had a user that tries to create a multisig with empty fields because it was not clear that the addresses are placeholder instead of actual values. With this change it should be more obvious that the placeholder is a placeholder.

<img width="601" alt="Bildschirmfoto 2022-01-28 um 16 17 11" src="https://user-images.githubusercontent.com/2603011/151572658-8679484b-9cd9-4fa8-b71c-c911e7552c0c.png">
<img width="601" alt="Bildschirmfoto 2022-01-28 um 16 17 21" src="https://user-images.githubusercontent.com/2603011/151572654-5f15c57c-0cd7-450c-9199-79746f6b55f0.png">
<img width="601" alt="Bildschirmfoto 2022-01-28 um 16 17 31" src="https://user-images.githubusercontent.com/2603011/151572650-a9fbe427-af41-42c9-a46d-63e766dae23c.png">
