### PR TITLE
Show signer address when connected

### DIFF
--- a/components/forms/TransactionSigning.tsx
+++ b/components/forms/TransactionSigning.tsx
@@ -134,20 +134,22 @@ const TransactionSigning = (props: Props) => {
       ) : (
         <>
           <h2>Sign this transaction</h2>
-          {walletAccount ? (
-            <>
-              <p>
-                Connected signer {walletAccount.bech32Address} (
-                {walletType ?? "Unknown wallet type"}).
-              </p>
-              <Button label="Sign transaction" onClick={signTransaction} />
-            </>
-          ) : (
-            <>
-              <Button label="Connect Keplr" onClick={connectKeplr} />
-              <Button label="Connect Ledger" onClick={connectLedger} />
-            </>
-          )}
+          <StackableContainer lessPadding lessMargin lessRadius>
+            {walletAccount ? (
+              <>
+                <p>
+                  Connected signer {walletAccount.bech32Address} (
+                  {walletType ?? "Unknown wallet type"}).
+                </p>
+                <Button label="Sign transaction" onClick={signTransaction} />
+              </>
+            ) : (
+              <>
+                <Button label="Connect Keplr" onClick={connectKeplr} />
+                <Button label="Connect Ledger (WebUSB)" onClick={connectLedger} />
+              </>
+            )}
+          </StackableContainer>
         </>
       )}
       {sigError && (


### PR DESCRIPTION
Based on #65.

Shows the signer address after the "Connect" step. Theis gives more feedback to the user and allows for better orientation before hitting "Sign".

https://user-images.githubusercontent.com/2603011/173827569-8591890b-fc89-41c7-b4e3-e9396ae95921.mov


