### PR TITLE
Fix chainId request parameter handling of getMultisig

### DIFF
--- a/pages/api/chain/[chainId]/multisig/[multisigAddress]/index.ts
+++ b/pages/api/chain/[chainId]/multisig/[multisigAddress]/index.ts
@@ -6,7 +6,7 @@ export default async function (req: NextApiRequest, res: NextApiResponse) {
     case "GET":
       try {
         const multisigAddress = req.query.multisigAddress.toString();
-        const chainId = req.query.multisigAddress.toString();
+        const chainId = req.query.chainId.toString();
         console.log("Function `getMultisig` invoked", multisigAddress, chainId);
         const getRes = await getMultisig(multisigAddress, chainId);
         if (!getRes.data.data.getMultisig) {


### PR DESCRIPTION
Without this fix, `multisigAddress` and `chainId` both contain the same value and the multisig is never found in the database.