### PR TITLE
Let getMultisigAccount always return a pubkey

### DIFF
--- a/components/dataViews/MultisigMembers.tsx
+++ b/components/dataViews/MultisigMembers.tsx
@@ -6,7 +6,7 @@ import StackableContainer from "../layout/StackableContainer";
 interface Props {
   /** Addresses of the multisig members */
   members: string[];
-  threshold: number;
+  threshold: string;
 }
 
 const MultisigMembers = (props: Props) => (

--- a/components/dataViews/ThresholdInfo.tsx
+++ b/components/dataViews/ThresholdInfo.tsx
@@ -1,14 +1,15 @@
 import React from "react";
+import { MultisigThresholdPubkey } from "@cosmjs/amino";
+
 import { DbSignature } from "../../types";
 import StackableContainer from "../layout/StackableContainer";
-import { AccountWithPubkey } from "../../lib/multisigHelpers";
 
 interface Props {
   signatures: DbSignature[];
-  account: AccountWithPubkey;
+  pubkey: MultisigThresholdPubkey;
 }
 
-const ThresholdInfo = ({ signatures, account }: Props) => (
+const ThresholdInfo = ({ signatures, pubkey }: Props) => (
   <StackableContainer lessPadding lessMargin>
     <h2>Signatures</h2>
     <StackableContainer lessPadding lessMargin lessRadius>
@@ -21,7 +22,7 @@ const ThresholdInfo = ({ signatures, account }: Props) => (
       <div className="threshold">
         <div className="current">{signatures.length}</div>
         <div className="label divider">of</div>
-        <div className="required">{account.pubkey.value.threshold}</div>
+        <div className="required">{pubkey.value.threshold}</div>
         <div className="label">signatures complete</div>
       </div>
     </StackableContainer>

--- a/components/forms/TransactionForm.tsx
+++ b/components/forms/TransactionForm.tsx
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { calculateFee } from "@cosmjs/stargate";
+import { Account, calculateFee } from "@cosmjs/stargate";
 import { Decimal } from "@cosmjs/math";
 import { assert } from "@cosmjs/utils";
 import React, { useState } from "react";
@@ -10,11 +10,10 @@ import Button from "../inputs/Button";
 import Input from "../inputs/Input";
 import StackableContainer from "../layout/StackableContainer";
 import { checkAddress, exampleAddress } from "../../lib/displayHelpers";
-import { AccountWithPubkey } from "../../lib/multisigHelpers";
 
 interface Props {
   address: string | null;
-  accountOnChain: AccountWithPubkey | null;
+  accountOnChain: Account | null;
   router: NextRouter;
   closeForm: () => void;
 }

--- a/lib/multisigHelpers.ts
+++ b/lib/multisigHelpers.ts
@@ -1,7 +1,13 @@
 import axios from "axios";
-import { createMultisigThresholdPubkey, Pubkey, pubkeyToAddress } from "@cosmjs/amino";
+import {
+  createMultisigThresholdPubkey,
+  isMultisigThresholdPubkey,
+  MultisigThresholdPubkey,
+  pubkeyToAddress,
+} from "@cosmjs/amino";
 import { Account } from "@cosmjs/stargate";
 import { StargateClient } from "@cosmjs/stargate";
+import { assert } from "@cosmjs/utils";
 
 /**
  * Turns array of compressed Secp256k1 pubkeys
@@ -40,12 +46,13 @@ const createMultisigFromCompressedSecp256k1Pubkeys = async (
   return res.data.address;
 };
 
-/** Like Account but with non-optional pubkey */
-export type AccountWithPubkey = Account & { readonly pubkey: Pubkey };
-
 /**
  * This gets a multisigs account (pubkey, sequence, account number, etc) from
- * a node and/or the api if the multisig was made on this app
+ * a node and/or the api if the multisig was made on this app.
+ *
+ * The public key should always be available, either on chain or in the app's database.
+ * The account is only available when the there was any on-chain activity such as
+ * receipt of tokens.
  *
  * @param {string} address The multisig address
  * @param client A connected stargate cosmoshub client
@@ -54,17 +61,20 @@ export type AccountWithPubkey = Account & { readonly pubkey: Pubkey };
 const getMultisigAccount = async (
   address: string,
   client: StargateClient,
-): Promise<AccountWithPubkey | null> => {
+): Promise<[MultisigThresholdPubkey, Account | null]> => {
   // we need the multisig pubkeys to create transactions, if the multisig
   // is new, and has never submitted a transaction its pubkeys will not be
   // available from a node. If the multisig was created with this instance
   // of this tool its pubkey will be available in the fauna datastore
   const accountOnChain = await client.getAccount(address);
   const chainId = await client.getChainId();
-  if (!accountOnChain) return null;
 
-  let pubkey: Pubkey;
-  if (accountOnChain.pubkey) {
+  let pubkey: MultisigThresholdPubkey;
+  if (accountOnChain?.pubkey) {
+    assert(
+      isMultisigThresholdPubkey(accountOnChain.pubkey),
+      "Pubkey on chain is not of type MultisigThreshold",
+    );
     pubkey = accountOnChain.pubkey;
   } else {
     console.log("No pubkey on chain for: ", address);
@@ -76,10 +86,7 @@ const getMultisigAccount = async (
     pubkey = JSON.parse(res.data.pubkeyJSON);
   }
 
-  return {
-    ...accountOnChain,
-    pubkey: pubkey,
-  };
+  return [pubkey, accountOnChain];
 };
 
 export { createMultisigFromCompressedSecp256k1Pubkeys, getMultisigAccount };

--- a/lib/multisigHelpers.ts
+++ b/lib/multisigHelpers.ts
@@ -53,10 +53,6 @@ const createMultisigFromCompressedSecp256k1Pubkeys = async (
  * The public key should always be available, either on chain or in the app's database.
  * The account is only available when the there was any on-chain activity such as
  * receipt of tokens.
- *
- * @param {string} address The multisig address
- * @param client A connected stargate cosmoshub client
- * @return {object} The multisig account.
  */
 const getMultisigAccount = async (
   address: string,


### PR DESCRIPTION
There was a case I missed in https://github.com/cosmos/cosmos-multisig-ui/pull/64: when creating a new multisig, the pubkey can be available in the app before we have an account on chain. This is needed to show the list of participants of a multisig address.

This change changes the types to always return the pubkey (either form chain or database) and keep the account optional.