### PR TITLE
Fixed pubkey not found in initial accounts

### DIFF
--- a/pages/multi/[address]/transaction/[transactionID].tsx
+++ b/pages/multi/[address]/transaction/[transactionID].tsx
@@ -112,9 +112,10 @@ const transactionPage = ({
       setBroadcastError("");
 
       assert(accountOnChain, "Account on chain value missing.");
+      assert(pubkey, "Pubkey not found on chain or in database");
       const bodyBytes = fromBase64(currentSignatures[0].bodyBytes);
       const signedTx = makeMultisignedTx(
-        accountOnChain.pubkey as MultisigThresholdPubkey,
+        pubkey as MultisigThresholdPubkey,
         txInfo.sequence,
         txInfo.fee,
         bodyBytes,

--- a/pages/multi/[address]/transaction/[transactionID].tsx
+++ b/pages/multi/[address]/transaction/[transactionID].tsx
@@ -115,7 +115,7 @@ const transactionPage = ({
       assert(pubkey, "Pubkey not found on chain or in database");
       const bodyBytes = fromBase64(currentSignatures[0].bodyBytes);
       const signedTx = makeMultisignedTx(
-        pubkey as MultisigThresholdPubkey,
+        pubkey,
         txInfo.sequence,
         txInfo.fee,
         bodyBytes,


### PR DESCRIPTION
Fixes a bug for newly created multisig account exist on-chain but not has pubkey.