### PR TITLE
Fix check validator address

### DIFF
--- a/components/forms/DelegationForm.tsx
+++ b/components/forms/DelegationForm.tsx
@@ -1,14 +1,14 @@
-import axios from "axios";
-import { Account, calculateFee } from "@cosmjs/stargate";
 import { Decimal } from "@cosmjs/math";
+import { Account, calculateFee } from "@cosmjs/stargate";
 import { assert } from "@cosmjs/utils";
+import axios from "axios";
+import { NextRouter, withRouter } from "next/router";
 import React, { useState } from "react";
-import { withRouter, NextRouter } from "next/router";
 import { useAppContext } from "../../context/AppContext";
+import { checkAddress } from "../../lib/displayHelpers";
 import Button from "../inputs/Button";
 import Input from "../inputs/Input";
 import StackableContainer from "../layout/StackableContainer";
-import { checkValidatorAddress } from "../../lib/displayHelpers";
 
 interface Props {
   address: string | null;
@@ -60,7 +60,7 @@ const DelegationForm = (props: Props) => {
 
   const handleCreate = async () => {
     assert(state.chain.addressPrefix, "addressPrefix missing");
-    const validatorAddressError = checkValidatorAddress(validatorAddress, "cosmosvaloper");
+    const validatorAddressError = checkAddress(validatorAddress, state.chain.addressPrefix);
     if (validatorAddressError) {
       setAddressError(
         `Invalid address for network ${state.chain.chainId}: ${validatorAddressError}`,
@@ -93,7 +93,7 @@ const DelegationForm = (props: Props) => {
           value={validatorAddress}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValidatorAddress(e.target.value)}
           error={addressError}
-          placeholder={`E.g. cosmosvaloper1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0`}
+          placeholder={`E.g. ${state.chain.addressPrefix}1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0`}
         />
       </div>
       <div className="form-item">

--- a/components/forms/DelegationForm.tsx
+++ b/components/forms/DelegationForm.tsx
@@ -5,7 +5,7 @@ import axios from "axios";
 import { NextRouter, withRouter } from "next/router";
 import React, { useState } from "react";
 import { useAppContext } from "../../context/AppContext";
-import { checkAddress } from "../../lib/displayHelpers";
+import { checkAddress, exampleValidatorAddress } from "../../lib/displayHelpers";
 import Button from "../inputs/Button";
 import Input from "../inputs/Input";
 import StackableContainer from "../layout/StackableContainer";
@@ -93,7 +93,7 @@ const DelegationForm = (props: Props) => {
           value={validatorAddress}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => setValidatorAddress(e.target.value)}
           error={addressError}
-          placeholder={`E.g. ${state.chain.addressPrefix}1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u2lcnj0`}
+          placeholder={`E.g. ${exampleValidatorAddress(0, state.chain.addressPrefix)}`}
         />
       </div>
       <div className="form-item">

--- a/lib/displayHelpers.ts
+++ b/lib/displayHelpers.ts
@@ -1,7 +1,7 @@
-import { fromBase64, fromBech32, toBase64, toBech32 } from "@cosmjs/encoding";
-import { sha512 } from "@cosmjs/crypto";
-import { Decimal } from "@cosmjs/math";
 import { Coin } from "@cosmjs/amino";
+import { sha512 } from "@cosmjs/crypto";
+import { fromBase64, fromBech32, toBase64, toBech32 } from "@cosmjs/encoding";
+import { Decimal } from "@cosmjs/math";
 import { ChainInfo } from "../types";
 
 /**
@@ -115,11 +115,11 @@ const checkAddress = (input: string, chainAddressPrefix: string) => {
     return error.toString();
   }
 
-  if (prefix !== chainAddressPrefix) {
+  if (!prefix.startsWith(chainAddressPrefix)) {
     return `Expected address prefix '${chainAddressPrefix}' but got '${prefix}'`;
   }
 
-  if (data.length !== 20) {
+  if (data.length < 20) {
     return "Invalid address length in bech32 data. Must be 20 bytes.";
   }
 

--- a/lib/displayHelpers.ts
+++ b/lib/displayHelpers.ts
@@ -81,6 +81,21 @@ const exampleAddress = (index: number, chainAddressPrefix: string) => {
 };
 
 /**
+ * Generates an example address for the configured blockchain.
+ *
+ * `index` can be set to a small integer in order to get different addresses. Defaults to 0.
+ */
+const exampleValidatorAddress = (index: number, chainAddressPrefix: string) => {
+  const usedIndex = index || 0;
+  let data = fromBech32("cosmosvaloper10v6wvdenee8r9l6wlsphcgur2ltl8ztkfrvj9a").data;
+  for (let i = 0; i < usedIndex; ++i) {
+    data = sha512(data).slice(0, data.length); // hash one time and trim to original length
+  }
+  const validatorPrefix = chainAddressPrefix + "valoper";
+  return toBech32(validatorPrefix, data);
+};
+
+/**
  * Generates an example pubkey (secp256k1, compressed).
  *
  * `index` can be set to a small integer in order to get different addresses. Defaults to 0.
@@ -142,6 +157,7 @@ export {
   printableCoin,
   printableCoins,
   exampleAddress,
+  exampleValidatorAddress,
   examplePubkey,
   checkAddress,
   explorerLinkTx,

--- a/lib/displayHelpers.ts
+++ b/lib/displayHelpers.ts
@@ -127,32 +127,6 @@ const checkAddress = (input: string, chainAddressPrefix: string) => {
 };
 
 /**
- * Returns an error message for invalid addresses.
- *
- * Returns null of there is no error.
- */
-const checkValidatorAddress = (input: string, chainAddressPrefix: string): string | null => {
-  if (!input) return "Empty";
-  let prefix;
-  try {
-    ({ prefix } = fromBech32(input));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    return error.toString();
-  }
-
-  if (prefix !== chainAddressPrefix) {
-    return `Expected address prefix '${chainAddressPrefix}' but got '${prefix}'`;
-  }
-
-  if (input.length !== 52) {
-    return "Invalid address length in validator address. Must be 52 bytes.";
-  }
-
-  return null;
-};
-
-/**
  * Returns a link to a transaction in an explorer if an explorer is configured
  * for transactions. Returns null otherwise.
  */
@@ -171,5 +145,4 @@ export {
   examplePubkey,
   checkAddress,
   explorerLinkTx,
-  checkValidatorAddress,
 };

--- a/lib/displayHelpers.ts
+++ b/lib/displayHelpers.ts
@@ -119,7 +119,7 @@ const checkAddress = (input: string, chainAddressPrefix: string) => {
     return `Expected address prefix '${chainAddressPrefix}' but got '${prefix}'`;
   }
 
-  if (data.length < 20) {
+  if (data.length !== 20) {
     return "Invalid address length in bech32 data. Must be 20 bytes.";
   }
 


### PR DESCRIPTION
Since the chains on the registry don't seem to usually set their `bech32_config` I made `checkAddress()` be less strict to include validator addresses.