### PR TITLE
Open address check to accept 32 byte addresses

### DIFF
--- a/components/forms/CreateTxForm/MsgForm/MsgTransferForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgTransferForm.tsx
@@ -75,7 +75,7 @@ const MsgTransferForm = ({ fromAddress, setMsgGetter, deleteMsg }: MsgTransferFo
         return false;
       }
 
-      const addressErrorMsg = checkAddress(toAddress, ""); // Allow address from any chain
+      const addressErrorMsg = checkAddress(toAddress, null); // Allow address from any chain
       if (addressErrorMsg) {
         setToAddressError(`Invalid address for network ${state.chain.chainId}: ${addressErrorMsg}`);
         return false;

--- a/lib/displayHelpers.ts
+++ b/lib/displayHelpers.ts
@@ -141,8 +141,8 @@ const checkAddress = (input: string, chainAddressPrefix: string | null) => {
     // any prefix is allowed
   }
 
-  if (data.length !== 20) {
-    return "Invalid address length in bech32 data. Must be 20 bytes.";
+  if (data.length !== 20 && data.length !== 32) {
+    return "Invalid address length in bech32 data. Expected 20 or 32 bytes.";
   }
 
   return null;

--- a/lib/displayHelpers.ts
+++ b/lib/displayHelpers.ts
@@ -117,10 +117,11 @@ function examplePubkey(index: number): string {
 
 /**
  * Returns an error message for invalid addresses.
- *
  * Returns null of there is no error.
+ *
+ * If `chainAddressPrefix` is null, the prefix check will be skipped.
  */
-const checkAddress = (input: string, chainAddressPrefix: string) => {
+const checkAddress = (input: string, chainAddressPrefix: string | null) => {
   if (!input) return "Empty";
 
   let data;
@@ -132,8 +133,12 @@ const checkAddress = (input: string, chainAddressPrefix: string) => {
     return error.toString();
   }
 
-  if (!prefix.startsWith(chainAddressPrefix)) {
-    return `Expected address prefix '${chainAddressPrefix}' but got '${prefix}'`;
+  if (chainAddressPrefix) {
+    if (!prefix.startsWith(chainAddressPrefix)) {
+      return `Expected address prefix '${chainAddressPrefix}' but got '${prefix}'`;
+    }
+  } else {
+    // any prefix is allowed
   }
 
   if (data.length !== 20) {


### PR DESCRIPTION
The chainAddressPrefix change is just cosmetics to make the clode clearer. It worked before as well.

The real change is allowing 32 bytes addresses (module accounts and CosmWasm contracts addresses)