### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "16"
-      - run: npm install
+          node-version: 18
       - run: npm run lint
 
   test:
@@ -25,8 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "16"
-      - run: npm install
+          node-version: 18
       - run: npm run test:ci
 
   build:
@@ -36,7 +34,6 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: "16"
-      - run: npm install
+          node-version: 18
       - run: cp .env.sample .env.local
       - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   lint:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18
       - run: npm run lint
@@ -20,9 +20,9 @@ jobs:
   test:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18
       - run: npm run test:ci
@@ -30,9 +30,9 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18
       - run: cp .env.sample .env.local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+      - run: npm ci
       - run: npm run lint
 
   test:
@@ -25,6 +26,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+      - run: npm ci
       - run: npm run test:ci
 
   build:
@@ -35,5 +37,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+      - run: npm ci
       - run: cp .env.sample .env.local
       - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: "npm"
       - run: npm ci
       - run: npm run lint
 
@@ -26,6 +27,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: "npm"
       - run: npm ci
       - run: npm run test:ci
 
@@ -37,6 +39,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
+          cache: "npm"
       - run: npm ci
       - run: cp .env.sample .env.local
       - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js
@@ -19,7 +19,7 @@ jobs:
       - run: npm run lint
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js
@@ -30,7 +30,7 @@ jobs:
       - run: npm run test:ci
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Setup Node.js


### PR DESCRIPTION
Changes:
- Uses latest Ubuntu LTS [release](https://wiki.ubuntu.com/Releases).
- Uses latest Node LTS [release](https://nodejs.org/en/download).
- Uses latest `actions/checkout` [release](https://github.com/actions/checkout).
- Uses latest `actions/setup-node` [release](https://github.com/actions/setup-node).
- Uses `npm ci` instead of `npm install` to [avoid updating](https://docs.npmjs.com/cli/v9/commands/npm-ci) the lockfile during CI process.
- Adds [cache](https://github.com/actions/setup-node#caching-global-packages-data) for npm with `actions/setup-node`.