### PR TITLE
Add default chain cosmoshub

### DIFF
--- a/context/ChainsContext/index.tsx
+++ b/context/ChainsContext/index.tsx
@@ -1,12 +1,7 @@
 import { ReactNode, createContext, useContext, useEffect, useReducer } from "react";
 import { emptyChain, isChainInfoFilled, setChain, setChains, setChainsError } from "./helpers";
 import { getChain, getNodeFromArray, useChainsFromRegistry } from "./service";
-import {
-  addLocalChainInStorage,
-  addRecentChainNameInStorage,
-  getRecentChainNamesFromStorage,
-  setChainInUrl,
-} from "./storage";
+import { addLocalChainInStorage, addRecentChainNameInStorage, setChainInUrl } from "./storage";
 import { Action, ChainsContextType, State } from "./types";
 
 const ChainsContext = createContext<ChainsContextType | undefined>(undefined);
@@ -66,9 +61,8 @@ export const ChainsProvider = ({ children }: ChainsProviderProps) => {
     setChainsError(dispatch, chainItemsError);
 
     const loadedChain = getChain(chainItems);
-    const recentChains = getRecentChainNamesFromStorage();
 
-    if (chainItems.mainnets.size && loadedChain === emptyChain && !recentChains.length) {
+    if (chainItems.mainnets.size && loadedChain === emptyChain) {
       setChain(dispatch, chainItems.mainnets.get("cosmoshub") ?? emptyChain);
     } else {
       setChain(dispatch, loadedChain);

--- a/context/ChainsContext/index.tsx
+++ b/context/ChainsContext/index.tsx
@@ -1,7 +1,12 @@
 import { ReactNode, createContext, useContext, useEffect, useReducer } from "react";
 import { emptyChain, isChainInfoFilled, setChain, setChains, setChainsError } from "./helpers";
 import { getChain, getNodeFromArray, useChainsFromRegistry } from "./service";
-import { addLocalChainInStorage, addRecentChainNameInStorage, setChainInUrl } from "./storage";
+import {
+  addLocalChainInStorage,
+  addRecentChainNameInStorage,
+  getRecentChainNamesFromStorage,
+  setChainInUrl,
+} from "./storage";
 import { Action, ChainsContextType, State } from "./types";
 
 const ChainsContext = createContext<ChainsContextType | undefined>(undefined);
@@ -61,7 +66,13 @@ export const ChainsProvider = ({ children }: ChainsProviderProps) => {
     setChainsError(dispatch, chainItemsError);
 
     const loadedChain = getChain(chainItems);
-    setChain(dispatch, loadedChain);
+    const recentChains = getRecentChainNamesFromStorage();
+
+    if (chainItems.mainnets.size && loadedChain === emptyChain && !recentChains.length) {
+      setChain(dispatch, chainItems.mainnets.get("cosmoshub") ?? emptyChain);
+    } else {
+      setChain(dispatch, loadedChain);
+    }
   }, [chainItems, chainItemsError]);
 
   useEffect(() => {


### PR DESCRIPTION
Closes #184.

If the user goes to the root page without any chainname (`https://cosmos-multisig-ui-kohl.vercel.app` instead of `https://cosmos-multisig-ui-kohl.vercel.app/<chain-name>`), it will be redirected to `https://cosmos-multisig-ui-kohl.vercel.app/cosmoshub` instead of staying in an infinite loading screen.