### PR TITLE
Validate macrocoin, allow empty funds and IBC

### DIFF
--- a/components/dataViews/TransactionInfo/TxMsgCreateVestingAccountDetails.tsx
+++ b/components/dataViews/TransactionInfo/TxMsgCreateVestingAccountDetails.tsx
@@ -20,7 +20,7 @@ const TxMsgCreateVestingAccountDetails = ({ msgValue }: TxMsgCreateVestingAccoun
       </li>
       <li>
         <label>Amount:</label>
-        <div>{printableCoins(msgValue.amount, chain)}</div>
+        <div>{printableCoins(msgValue.amount, chain) || "None"}</div>
       </li>
       <li>
         <label>From:</label>

--- a/components/dataViews/TransactionInfo/TxMsgExecuteContractDetails.tsx
+++ b/components/dataViews/TransactionInfo/TxMsgExecuteContractDetails.tsx
@@ -43,7 +43,7 @@ const TxMsgExecuteContractDetails = ({ msgValue }: TxMsgExecuteContractDetailsPr
       </li>
       <li>
         <label>Funds:</label>
-        <div>{printableCoins(msgValue.funds, chain)}</div>
+        <div>{printableCoins(msgValue.funds, chain) || "None"}</div>
       </li>
       {parseError ? (
         <li className="parse-error">

--- a/components/dataViews/TransactionInfo/TxMsgInstantiateContract2Details.tsx
+++ b/components/dataViews/TransactionInfo/TxMsgInstantiateContract2Details.tsx
@@ -59,7 +59,7 @@ const TxMsgInstantiateContract2Details = ({ msgValue }: TxMsgInstantiateContract
       </li>
       <li>
         <label>Funds:</label>
-        <div>{printableCoins(msgValue.funds, chain)}</div>
+        <div>{printableCoins(msgValue.funds, chain) || "None"}</div>
       </li>
       {parseError ? (
         <li className="parse-error">

--- a/components/dataViews/TransactionInfo/TxMsgInstantiateContractDetails.tsx
+++ b/components/dataViews/TransactionInfo/TxMsgInstantiateContractDetails.tsx
@@ -55,7 +55,7 @@ const TxMsgInstantiateContractDetails = ({ msgValue }: TxMsgInstantiateContractD
       </li>
       <li>
         <label>Funds:</label>
-        <div>{printableCoins(msgValue.funds, chain)}</div>
+        <div>{printableCoins(msgValue.funds, chain) || "None"}</div>
       </li>
       {parseError ? (
         <li className="parse-error">

--- a/components/dataViews/TransactionInfo/TxMsgSendDetails.tsx
+++ b/components/dataViews/TransactionInfo/TxMsgSendDetails.tsx
@@ -17,7 +17,7 @@ const TxMsgSendDetails = ({ msgValue }: TxMsgSendDetailsProps) => {
       </li>
       <li>
         <label>Amount:</label>
-        <div>{printableCoins(msgValue.amount, chain)}</div>
+        <div>{printableCoins(msgValue.amount, chain) || "None"}</div>
       </li>
       <li>
         <label>To:</label>

--- a/components/dataViews/TransactionInfo/index.tsx
+++ b/components/dataViews/TransactionInfo/index.tsx
@@ -68,7 +68,7 @@ const TransactionInfo = ({ tx }: TransactionInfoProps) => {
                 </li>
                 <li>
                   <label>Fee:</label>
-                  <div>{printableCoins(tx.fee.amount, chain)}</div>
+                  <div>{printableCoins(tx.fee.amount, chain) || "None"}</div>
                 </li>
               </>
             ) : null}

--- a/components/forms/CreateTxForm/MsgForm/MsgCreateVestingAccountForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgCreateVestingAccountForm.tsx
@@ -58,6 +58,13 @@ const MsgCreateVestingAccountForm = ({
         return false;
       }
 
+      try {
+        macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
+      } catch (e: unknown) {
+        setAmountError(e instanceof Error ? e.message : "Could not set decimals");
+        return false;
+      }
+
       const timeoutDate = new Date(Number(timestampFromDatetimeLocal(endTime, "ms")));
       if (timeoutDate <= new Date()) {
         setEndTimeError("End time must be a date in the future");

--- a/components/forms/CreateTxForm/MsgForm/MsgCreateVestingAccountForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgCreateVestingAccountForm.tsx
@@ -78,14 +78,14 @@ const MsgCreateVestingAccountForm = ({
       try {
         return macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
       } catch {
-        return { denom: chain.displayDenom, amount: "0" };
+        return null;
       }
     })();
 
     const msgValue = MsgCodecs[MsgTypeUrls.CreateVestingAccount].fromPartial({
       fromAddress,
       toAddress,
-      amount: [microCoin],
+      amount: microCoin ? [microCoin] : [],
       endTime: timestampFromDatetimeLocal(endTime, "s"),
       delayed,
     });

--- a/components/forms/CreateTxForm/MsgForm/MsgCreateVestingAccountForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgCreateVestingAccountForm.tsx
@@ -76,6 +76,10 @@ const MsgCreateVestingAccountForm = ({
 
     const microCoin = (() => {
       try {
+        if (!amount || amount === "0") {
+          return null;
+        }
+
         return macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
       } catch {
         return null;

--- a/components/forms/CreateTxForm/MsgForm/MsgCreateVestingAccountForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgCreateVestingAccountForm.tsx
@@ -2,7 +2,7 @@ import { EncodeObject } from "@cosmjs/proto-signing";
 import { useEffect, useState } from "react";
 import { MsgGetter } from "..";
 import { useChains } from "../../../../context/ChainsContext";
-import { macroCoinToMicroCoin } from "../../../../lib/coinHelpers";
+import { displayCoinToBaseCoin } from "../../../../lib/coinHelpers";
 import {
   datetimeLocalFromTimestamp,
   timestampFromDatetimeLocal,
@@ -59,7 +59,7 @@ const MsgCreateVestingAccountForm = ({
       }
 
       try {
-        macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
+        displayCoinToBaseCoin({ denom: chain.displayDenom, amount }, chain.assets);
       } catch (e: unknown) {
         setAmountError(e instanceof Error ? e.message : "Could not set decimals");
         return false;
@@ -80,7 +80,7 @@ const MsgCreateVestingAccountForm = ({
           return null;
         }
 
-        return macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
+        return displayCoinToBaseCoin({ denom: chain.displayDenom, amount }, chain.assets);
       } catch {
         return null;
       }

--- a/components/forms/CreateTxForm/MsgForm/MsgDelegateForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgDelegateForm.tsx
@@ -46,6 +46,13 @@ const MsgDelegateForm = ({ delegatorAddress, setMsgGetter, deleteMsg }: MsgDeleg
         return false;
       }
 
+      try {
+        macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
+      } catch (e: unknown) {
+        setAmountError(e instanceof Error ? e.message : "Could not set decimals");
+        return false;
+      }
+
       return true;
     };
 

--- a/components/forms/CreateTxForm/MsgForm/MsgDelegateForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgDelegateForm.tsx
@@ -2,7 +2,7 @@ import { MsgDelegateEncodeObject } from "@cosmjs/stargate";
 import { useEffect, useState } from "react";
 import { MsgGetter } from "..";
 import { useChains } from "../../../../context/ChainsContext";
-import { macroCoinToMicroCoin } from "../../../../lib/coinHelpers";
+import { displayCoinToBaseCoin } from "../../../../lib/coinHelpers";
 import { checkAddress, exampleAddress, trimStringsObj } from "../../../../lib/displayHelpers";
 import { MsgCodecs, MsgTypeUrls } from "../../../../types/txMsg";
 import Input from "../../../inputs/Input";
@@ -47,7 +47,7 @@ const MsgDelegateForm = ({ delegatorAddress, setMsgGetter, deleteMsg }: MsgDeleg
       }
 
       try {
-        macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
+        displayCoinToBaseCoin({ denom: chain.displayDenom, amount }, chain.assets);
       } catch (e: unknown) {
         setAmountError(e instanceof Error ? e.message : "Could not set decimals");
         return false;
@@ -58,7 +58,7 @@ const MsgDelegateForm = ({ delegatorAddress, setMsgGetter, deleteMsg }: MsgDeleg
 
     const microCoin = (() => {
       try {
-        return macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
+        return displayCoinToBaseCoin({ denom: chain.displayDenom, amount }, chain.assets);
       } catch {
         return { denom: chain.displayDenom, amount: "0" };
       }

--- a/components/forms/CreateTxForm/MsgForm/MsgExecuteContractForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgExecuteContractForm.tsx
@@ -55,6 +55,8 @@ const MsgExecuteContractForm = ({
   useEffect(() => {
     // eslint-disable-next-line no-shadow
     const { contractAddress, customDenom, amount } = trimmedInputs;
+    const denom =
+      selectedDenom.value === customDenomOption.value ? customDenom : selectedDenom.value.symbol;
 
     const isMsgValid = (): boolean => {
       setContractAddressError("");
@@ -86,24 +88,23 @@ const MsgExecuteContractForm = ({
         return false;
       }
 
-      try {
-        macroCoinToMicroCoin({ denom, amount }, chain.assets);
-      } catch (e: unknown) {
-        setAmountError(e instanceof Error ? e.message : "Could not set decimals");
-        return false;
+      if (denom && amount) {
+        try {
+          macroCoinToMicroCoin({ denom, amount }, chain.assets);
+        } catch (e: unknown) {
+          setAmountError(e instanceof Error ? e.message : "Could not set decimals");
+          return false;
+        }
       }
 
       return true;
     };
 
-    const denom =
-      selectedDenom.value === customDenomOption.value ? customDenom : selectedDenom.value.symbol;
-
     const microCoin = (() => {
       try {
         return macroCoinToMicroCoin({ denom, amount }, chain.assets);
       } catch {
-        return { denom, amount: "0" };
+        return null;
       }
     })();
 
@@ -120,7 +121,7 @@ const MsgExecuteContractForm = ({
       sender: fromAddress,
       contract: contractAddress,
       msg: msgContentUtf8Array,
-      funds: [microCoin],
+      funds: microCoin ? [microCoin] : [],
     });
 
     const msg: MsgExecuteContractEncodeObject = { typeUrl: MsgTypeUrls.Execute, value: msgValue };

--- a/components/forms/CreateTxForm/MsgForm/MsgExecuteContractForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgExecuteContractForm.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { MsgGetter } from "..";
 import { useChains } from "../../../../context/ChainsContext";
 import { ChainInfo } from "../../../../context/ChainsContext/types";
-import { macroCoinToMicroCoin } from "../../../../lib/coinHelpers";
+import { displayCoinToBaseCoin } from "../../../../lib/coinHelpers";
 import { checkAddress, exampleAddress, trimStringsObj } from "../../../../lib/displayHelpers";
 import { MsgCodecs, MsgTypeUrls } from "../../../../types/txMsg";
 import Input from "../../../inputs/Input";
@@ -95,7 +95,7 @@ const MsgExecuteContractForm = ({
 
       if (denom && amount) {
         try {
-          macroCoinToMicroCoin({ denom, amount }, chain.assets);
+          displayCoinToBaseCoin({ denom, amount }, chain.assets);
         } catch (e: unknown) {
           setAmountError(e instanceof Error ? e.message : "Could not set decimals");
           return false;
@@ -111,7 +111,7 @@ const MsgExecuteContractForm = ({
           return null;
         }
 
-        return macroCoinToMicroCoin({ denom, amount }, chain.assets);
+        return displayCoinToBaseCoin({ denom, amount }, chain.assets);
       } catch {
         return null;
       }

--- a/components/forms/CreateTxForm/MsgForm/MsgExecuteContractForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgExecuteContractForm.tsx
@@ -86,6 +86,13 @@ const MsgExecuteContractForm = ({
         return false;
       }
 
+      try {
+        macroCoinToMicroCoin({ denom, amount }, chain.assets);
+      } catch (e: unknown) {
+        setAmountError(e instanceof Error ? e.message : "Could not set decimals");
+        return false;
+      }
+
       return true;
     };
 

--- a/components/forms/CreateTxForm/MsgForm/MsgExecuteContractForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgExecuteContractForm.tsx
@@ -73,7 +73,12 @@ const MsgExecuteContractForm = ({
         return false;
       }
 
-      if (selectedDenom.value === customDenomOption.value && !customDenom) {
+      if (
+        selectedDenom.value === customDenomOption.value &&
+        !customDenom &&
+        amount &&
+        amount !== "0"
+      ) {
         setCustomDenomError("Custom denom must be set because of selection above");
         return false;
       }
@@ -102,6 +107,10 @@ const MsgExecuteContractForm = ({
 
     const microCoin = (() => {
       try {
+        if (!denom || !amount || amount === "0") {
+          return null;
+        }
+
         return macroCoinToMicroCoin({ denom, amount }, chain.assets);
       } catch {
         return null;
@@ -123,6 +132,8 @@ const MsgExecuteContractForm = ({
       msg: msgContentUtf8Array,
       funds: microCoin ? [microCoin] : [],
     });
+
+    console.log({ msgValue });
 
     const msg: MsgExecuteContractEncodeObject = { typeUrl: MsgTypeUrls.Execute, value: msgValue };
 

--- a/components/forms/CreateTxForm/MsgForm/MsgExecuteContractForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgExecuteContractForm.tsx
@@ -133,8 +133,6 @@ const MsgExecuteContractForm = ({
       funds: microCoin ? [microCoin] : [],
     });
 
-    console.log({ msgValue });
-
     const msg: MsgExecuteContractEncodeObject = { typeUrl: MsgTypeUrls.Execute, value: msgValue };
 
     setMsgGetter({ isMsgValid, msg });

--- a/components/forms/CreateTxForm/MsgForm/MsgInstantiateContract2Form.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgInstantiateContract2Form.tsx
@@ -116,6 +116,13 @@ const MsgInstantiateContract2Form = ({
         return false;
       }
 
+      try {
+        macroCoinToMicroCoin({ denom, amount }, chain.assets);
+      } catch (e: unknown) {
+        setAmountError(e instanceof Error ? e.message : "Could not set decimals");
+        return false;
+      }
+
       return true;
     };
 

--- a/components/forms/CreateTxForm/MsgForm/MsgInstantiateContract2Form.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgInstantiateContract2Form.tsx
@@ -133,7 +133,7 @@ const MsgInstantiateContract2Form = ({
       try {
         return macroCoinToMicroCoin({ denom, amount }, chain.assets);
       } catch {
-        return { denom, amount: "0" };
+        return null;
       }
     })();
 
@@ -162,7 +162,7 @@ const MsgInstantiateContract2Form = ({
       fixMsg: false,
       salt: hexSalt,
       msg: msgContentUtf8Array,
-      funds: [microCoin],
+      funds: microCoin ? [microCoin] : [],
     });
 
     const msg: MsgInstantiateContract2EncodeObject = {

--- a/components/forms/CreateTxForm/MsgForm/MsgInstantiateContract2Form.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgInstantiateContract2Form.tsx
@@ -101,7 +101,12 @@ const MsgInstantiateContract2Form = ({
         return false;
       }
 
-      if (selectedDenom.value === customDenomOption.value && !customDenom) {
+      if (
+        selectedDenom.value === customDenomOption.value &&
+        !customDenom &&
+        amount &&
+        amount !== "0"
+      ) {
         setCustomDenomError("Custom denom must be set because of selection above");
         return false;
       }
@@ -131,6 +136,10 @@ const MsgInstantiateContract2Form = ({
 
     const microCoin = (() => {
       try {
+        if (!denom || !amount || amount === "0") {
+          return null;
+        }
+
         return macroCoinToMicroCoin({ denom, amount }, chain.assets);
       } catch {
         return null;

--- a/components/forms/CreateTxForm/MsgForm/MsgInstantiateContract2Form.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgInstantiateContract2Form.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { MsgGetter } from "..";
 import { useChains } from "../../../../context/ChainsContext";
 import { ChainInfo } from "../../../../context/ChainsContext/types";
-import { macroCoinToMicroCoin } from "../../../../lib/coinHelpers";
+import { displayCoinToBaseCoin } from "../../../../lib/coinHelpers";
 import { checkAddress, exampleAddress, trimStringsObj } from "../../../../lib/displayHelpers";
 import { MsgCodecs, MsgTypeUrls } from "../../../../types/txMsg";
 import Input from "../../../inputs/Input";
@@ -122,7 +122,7 @@ const MsgInstantiateContract2Form = ({
       }
 
       try {
-        macroCoinToMicroCoin({ denom, amount }, chain.assets);
+        displayCoinToBaseCoin({ denom, amount }, chain.assets);
       } catch (e: unknown) {
         setAmountError(e instanceof Error ? e.message : "Could not set decimals");
         return false;
@@ -140,7 +140,7 @@ const MsgInstantiateContract2Form = ({
           return null;
         }
 
-        return macroCoinToMicroCoin({ denom, amount }, chain.assets);
+        return displayCoinToBaseCoin({ denom, amount }, chain.assets);
       } catch {
         return null;
       }

--- a/components/forms/CreateTxForm/MsgForm/MsgInstantiateContractForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgInstantiateContractForm.tsx
@@ -102,6 +102,13 @@ const MsgInstantiateContractForm = ({
         return false;
       }
 
+      try {
+        macroCoinToMicroCoin({ denom, amount }, chain.assets);
+      } catch (e: unknown) {
+        setAmountError(e instanceof Error ? e.message : "Could not set decimals");
+        return false;
+      }
+
       return true;
     };
 

--- a/components/forms/CreateTxForm/MsgForm/MsgInstantiateContractForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgInstantiateContractForm.tsx
@@ -119,7 +119,7 @@ const MsgInstantiateContractForm = ({
       try {
         return macroCoinToMicroCoin({ denom, amount }, chain.assets);
       } catch {
-        return { denom, amount: "0" };
+        return null;
       }
     })();
 
@@ -138,7 +138,7 @@ const MsgInstantiateContractForm = ({
       label,
       admin: adminAddress,
       msg: msgContentUtf8Array,
-      funds: [microCoin],
+      funds: microCoin ? [microCoin] : [],
     });
 
     const msg: MsgInstantiateContractEncodeObject = {

--- a/components/forms/CreateTxForm/MsgForm/MsgInstantiateContractForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgInstantiateContractForm.tsx
@@ -87,7 +87,12 @@ const MsgInstantiateContractForm = ({
         return false;
       }
 
-      if (selectedDenom.value === customDenomOption.value && !customDenom) {
+      if (
+        selectedDenom.value === customDenomOption.value &&
+        !customDenom &&
+        amount &&
+        amount !== "0"
+      ) {
         setCustomDenomError("Custom denom must be set because of selection above");
         return false;
       }
@@ -117,6 +122,10 @@ const MsgInstantiateContractForm = ({
 
     const microCoin = (() => {
       try {
+        if (!denom || !amount || amount === "0") {
+          return null;
+        }
+
         return macroCoinToMicroCoin({ denom, amount }, chain.assets);
       } catch {
         return null;

--- a/components/forms/CreateTxForm/MsgForm/MsgInstantiateContractForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgInstantiateContractForm.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { MsgGetter } from "..";
 import { useChains } from "../../../../context/ChainsContext";
 import { ChainInfo } from "../../../../context/ChainsContext/types";
-import { macroCoinToMicroCoin } from "../../../../lib/coinHelpers";
+import { displayCoinToBaseCoin } from "../../../../lib/coinHelpers";
 import { checkAddress, exampleAddress, trimStringsObj } from "../../../../lib/displayHelpers";
 import { MsgCodecs, MsgTypeUrls } from "../../../../types/txMsg";
 import Input from "../../../inputs/Input";
@@ -108,7 +108,7 @@ const MsgInstantiateContractForm = ({
       }
 
       try {
-        macroCoinToMicroCoin({ denom, amount }, chain.assets);
+        displayCoinToBaseCoin({ denom, amount }, chain.assets);
       } catch (e: unknown) {
         setAmountError(e instanceof Error ? e.message : "Could not set decimals");
         return false;
@@ -126,7 +126,7 @@ const MsgInstantiateContractForm = ({
           return null;
         }
 
-        return macroCoinToMicroCoin({ denom, amount }, chain.assets);
+        return displayCoinToBaseCoin({ denom, amount }, chain.assets);
       } catch {
         return null;
       }

--- a/components/forms/CreateTxForm/MsgForm/MsgRedelegateForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgRedelegateForm.tsx
@@ -61,6 +61,13 @@ const MsgRedelegateForm = ({
         return false;
       }
 
+      try {
+        macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
+      } catch (e: unknown) {
+        setAmountError(e instanceof Error ? e.message : "Could not set decimals");
+        return false;
+      }
+
       return true;
     };
 

--- a/components/forms/CreateTxForm/MsgForm/MsgRedelegateForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgRedelegateForm.tsx
@@ -2,7 +2,7 @@ import { EncodeObject } from "@cosmjs/proto-signing";
 import { useEffect, useState } from "react";
 import { MsgGetter } from "..";
 import { useChains } from "../../../../context/ChainsContext";
-import { macroCoinToMicroCoin } from "../../../../lib/coinHelpers";
+import { displayCoinToBaseCoin } from "../../../../lib/coinHelpers";
 import { checkAddress, exampleAddress, trimStringsObj } from "../../../../lib/displayHelpers";
 import { MsgCodecs, MsgTypeUrls } from "../../../../types/txMsg";
 import Input from "../../../inputs/Input";
@@ -62,7 +62,7 @@ const MsgRedelegateForm = ({
       }
 
       try {
-        macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
+        displayCoinToBaseCoin({ denom: chain.displayDenom, amount }, chain.assets);
       } catch (e: unknown) {
         setAmountError(e instanceof Error ? e.message : "Could not set decimals");
         return false;
@@ -73,7 +73,7 @@ const MsgRedelegateForm = ({
 
     const microCoin = (() => {
       try {
-        return macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
+        return displayCoinToBaseCoin({ denom: chain.displayDenom, amount }, chain.assets);
       } catch {
         return { denom: chain.displayDenom, amount: "0" };
       }

--- a/components/forms/CreateTxForm/MsgForm/MsgSendForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgSendForm.tsx
@@ -2,7 +2,7 @@ import { MsgSendEncodeObject } from "@cosmjs/stargate";
 import { useEffect, useState } from "react";
 import { MsgGetter } from "..";
 import { useChains } from "../../../../context/ChainsContext";
-import { macroCoinToMicroCoin } from "../../../../lib/coinHelpers";
+import { displayCoinToBaseCoin } from "../../../../lib/coinHelpers";
 import { checkAddress, exampleAddress, trimStringsObj } from "../../../../lib/displayHelpers";
 import { RegistryAsset } from "../../../../types/chainRegistry";
 import { MsgCodecs, MsgTypeUrls } from "../../../../types/txMsg";
@@ -78,7 +78,7 @@ const MsgSendForm = ({ fromAddress, setMsgGetter, deleteMsg }: MsgSendFormProps)
       }
 
       try {
-        macroCoinToMicroCoin({ denom, amount }, chain.assets);
+        displayCoinToBaseCoin({ denom, amount }, chain.assets);
       } catch (e: unknown) {
         setAmountError(e instanceof Error ? e.message : "Could not set decimals");
         return false;
@@ -96,7 +96,7 @@ const MsgSendForm = ({ fromAddress, setMsgGetter, deleteMsg }: MsgSendFormProps)
           return null;
         }
 
-        return macroCoinToMicroCoin({ denom, amount }, chain.assets);
+        return displayCoinToBaseCoin({ denom, amount }, chain.assets);
       } catch {
         return null;
       }

--- a/components/forms/CreateTxForm/MsgForm/MsgSendForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgSendForm.tsx
@@ -72,6 +72,13 @@ const MsgSendForm = ({ fromAddress, setMsgGetter, deleteMsg }: MsgSendFormProps)
         return false;
       }
 
+      try {
+        macroCoinToMicroCoin({ denom, amount }, chain.assets);
+      } catch (e: unknown) {
+        setAmountError(e instanceof Error ? e.message : "Could not set decimals");
+        return false;
+      }
+
       return true;
     };
 

--- a/components/forms/CreateTxForm/MsgForm/MsgSendForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgSendForm.tsx
@@ -89,14 +89,14 @@ const MsgSendForm = ({ fromAddress, setMsgGetter, deleteMsg }: MsgSendFormProps)
       try {
         return macroCoinToMicroCoin({ denom, amount }, chain.assets);
       } catch {
-        return { denom, amount: "0" };
+        return null;
       }
     })();
 
     const msgValue = MsgCodecs[MsgTypeUrls.Send].fromPartial({
       fromAddress,
       toAddress,
-      amount: [microCoin],
+      amount: microCoin ? [microCoin] : [],
     });
 
     const msg: MsgSendEncodeObject = { typeUrl: MsgTypeUrls.Send, value: msgValue };

--- a/components/forms/CreateTxForm/MsgForm/MsgSendForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgSendForm.tsx
@@ -57,7 +57,12 @@ const MsgSendForm = ({ fromAddress, setMsgGetter, deleteMsg }: MsgSendFormProps)
         return false;
       }
 
-      if (selectedDenom.value === customDenomOption.value && !customDenom) {
+      if (
+        selectedDenom.value === customDenomOption.value &&
+        !customDenom &&
+        amount &&
+        amount !== "0"
+      ) {
         setCustomDenomError("Custom denom must be set because of selection above");
         return false;
       }
@@ -87,6 +92,10 @@ const MsgSendForm = ({ fromAddress, setMsgGetter, deleteMsg }: MsgSendFormProps)
 
     const microCoin = (() => {
       try {
+        if (!denom || !amount || amount === "0") {
+          return null;
+        }
+
         return macroCoinToMicroCoin({ denom, amount }, chain.assets);
       } catch {
         return null;

--- a/components/forms/CreateTxForm/MsgForm/MsgUndelegateForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgUndelegateForm.tsx
@@ -2,7 +2,7 @@ import { MsgUndelegateEncodeObject } from "@cosmjs/stargate";
 import { useEffect, useState } from "react";
 import { MsgGetter } from "..";
 import { useChains } from "../../../../context/ChainsContext";
-import { macroCoinToMicroCoin } from "../../../../lib/coinHelpers";
+import { displayCoinToBaseCoin } from "../../../../lib/coinHelpers";
 import { checkAddress, exampleAddress, trimStringsObj } from "../../../../lib/displayHelpers";
 import { MsgCodecs, MsgTypeUrls } from "../../../../types/txMsg";
 import Input from "../../../inputs/Input";
@@ -51,7 +51,7 @@ const MsgUndelegateForm = ({
       }
 
       try {
-        macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
+        displayCoinToBaseCoin({ denom: chain.displayDenom, amount }, chain.assets);
       } catch (e: unknown) {
         setAmountError(e instanceof Error ? e.message : "Could not set decimals");
         return false;
@@ -62,7 +62,7 @@ const MsgUndelegateForm = ({
 
     const microCoin = (() => {
       try {
-        return macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
+        return displayCoinToBaseCoin({ denom: chain.displayDenom, amount }, chain.assets);
       } catch {
         return { denom: chain.displayDenom, amount: "0" };
       }

--- a/components/forms/CreateTxForm/MsgForm/MsgUndelegateForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgUndelegateForm.tsx
@@ -50,6 +50,13 @@ const MsgUndelegateForm = ({
         return false;
       }
 
+      try {
+        macroCoinToMicroCoin({ denom: chain.displayDenom, amount }, chain.assets);
+      } catch (e: unknown) {
+        setAmountError(e instanceof Error ? e.message : "Could not set decimals");
+        return false;
+      }
+
       return true;
     };
 

--- a/lib/coinHelpers.spec.ts
+++ b/lib/coinHelpers.spec.ts
@@ -1,5 +1,5 @@
 import { RegistryAsset } from "../types/chainRegistry";
-import { macroCoinToMicroCoin } from "./coinHelpers";
+import { displayCoinToBaseCoin } from "./coinHelpers";
 
 const assets: readonly RegistryAsset[] = [
   {
@@ -75,70 +75,70 @@ const assets: readonly RegistryAsset[] = [
 
 describe("macroCoinToMicroCoin", () => {
   it("works with symbol", () => {
-    expect(macroCoinToMicroCoin({ denom: "JUNOX", amount: "12" }, assets)).toEqual({
+    expect(displayCoinToBaseCoin({ denom: "JUNOX", amount: "12" }, assets)).toEqual({
       denom: "ujunox",
       amount: "12000000",
     });
-    expect(macroCoinToMicroCoin({ denom: "CHEQ", amount: "34" }, assets)).toEqual({
+    expect(displayCoinToBaseCoin({ denom: "CHEQ", amount: "34" }, assets)).toEqual({
       denom: "ncheq",
       amount: "34000000000",
     });
-    expect(macroCoinToMicroCoin({ denom: "arUSD", amount: "56" }, assets)).toEqual({
+    expect(displayCoinToBaseCoin({ denom: "arUSD", amount: "56" }, assets)).toEqual({
       denom: "erc20/0x2Cbea61fdfDFA520Ee99700F104D5b75ADf50B0c",
       amount: "56000000000000000000",
     });
-    expect(macroCoinToMicroCoin({ denom: "ETH", amount: "78" }, assets)).toEqual({
+    expect(displayCoinToBaseCoin({ denom: "ETH", amount: "78" }, assets)).toEqual({
       denom: "wei",
       amount: "78000000000000000000",
     });
   });
 
   it("works with base unit", () => {
-    expect(macroCoinToMicroCoin({ denom: "ujunox", amount: "12" }, assets)).toEqual({
+    expect(displayCoinToBaseCoin({ denom: "ujunox", amount: "12" }, assets)).toEqual({
       denom: "ujunox",
       amount: "12",
     });
-    expect(macroCoinToMicroCoin({ denom: "ncheq", amount: "34" }, assets)).toEqual({
+    expect(displayCoinToBaseCoin({ denom: "ncheq", amount: "34" }, assets)).toEqual({
       denom: "ncheq",
       amount: "34",
     });
     expect(
-      macroCoinToMicroCoin(
+      displayCoinToBaseCoin(
         { denom: "erc20/0x2Cbea61fdfDFA520Ee99700F104D5b75ADf50B0c", amount: "56" },
         assets,
       ),
     ).toEqual({ denom: "erc20/0x2Cbea61fdfDFA520Ee99700F104D5b75ADf50B0c", amount: "56" });
-    expect(macroCoinToMicroCoin({ denom: "wei", amount: "78" }, assets)).toEqual({
+    expect(displayCoinToBaseCoin({ denom: "wei", amount: "78" }, assets)).toEqual({
       denom: "wei",
       amount: "78",
     });
   });
 
   it("works with biggest unit", () => {
-    expect(macroCoinToMicroCoin({ denom: "junox", amount: "12" }, assets)).toEqual({
+    expect(displayCoinToBaseCoin({ denom: "junox", amount: "12" }, assets)).toEqual({
       denom: "ujunox",
       amount: "12000000",
     });
-    expect(macroCoinToMicroCoin({ denom: "cheq", amount: "34" }, assets)).toEqual({
+    expect(displayCoinToBaseCoin({ denom: "cheq", amount: "34" }, assets)).toEqual({
       denom: "ncheq",
       amount: "34000000000",
     });
-    expect(macroCoinToMicroCoin({ denom: "arusd", amount: "56" }, assets)).toEqual({
+    expect(displayCoinToBaseCoin({ denom: "arusd", amount: "56" }, assets)).toEqual({
       denom: "erc20/0x2Cbea61fdfDFA520Ee99700F104D5b75ADf50B0c",
       amount: "56000000000000000000",
     });
-    expect(macroCoinToMicroCoin({ denom: "eth", amount: "78" }, assets)).toEqual({
+    expect(displayCoinToBaseCoin({ denom: "eth", amount: "78" }, assets)).toEqual({
       denom: "wei",
       amount: "78000000000000000000",
     });
   });
 
   it("works with intermediate unit", () => {
-    expect(macroCoinToMicroCoin({ denom: "gwei", amount: "78" }, assets)).toEqual({
+    expect(displayCoinToBaseCoin({ denom: "gwei", amount: "78" }, assets)).toEqual({
       denom: "wei",
       amount: "78000000000",
     });
-    expect(macroCoinToMicroCoin({ denom: "GWEI", amount: "78" }, assets)).toEqual({
+    expect(displayCoinToBaseCoin({ denom: "GWEI", amount: "78" }, assets)).toEqual({
       denom: "wei",
       amount: "78000000000",
     });

--- a/lib/coinHelpers.ts
+++ b/lib/coinHelpers.ts
@@ -17,6 +17,11 @@ const macroCoinToMicroCoin = (macroCoin: Coin, assets: readonly RegistryAsset[])
       ),
   );
 
+  // Leave IBC coins as is if not found on registry assets
+  if (!asset && macroCoin.denom.toLowerCase().startsWith("ibc/")) {
+    return macroCoin;
+  }
+
   assert(asset, `An asset with the given symbol ${macroCoin.denom} was not found`);
 
   const macroUnit = asset.denom_units.find(

--- a/lib/coinHelpers.ts
+++ b/lib/coinHelpers.ts
@@ -3,8 +3,8 @@ import { Coin } from "@cosmjs/stargate";
 import { assert } from "@cosmjs/utils";
 import { RegistryAsset } from "../types/chainRegistry";
 
-const macroCoinToMicroCoin = (macroCoin: Coin, assets: readonly RegistryAsset[]): Coin => {
-  const lowerCaseDenom = macroCoin.denom.toLowerCase();
+const displayCoinToBaseCoin = (displayCoin: Coin, assets: readonly RegistryAsset[]): Coin => {
+  const lowerCaseDenom = displayCoin.denom.toLowerCase();
 
   const asset = assets.find(
     (currentAsset) =>
@@ -18,11 +18,11 @@ const macroCoinToMicroCoin = (macroCoin: Coin, assets: readonly RegistryAsset[])
   );
 
   // Leave IBC coins as is if not found on registry assets
-  if (!asset && macroCoin.denom.toLowerCase().startsWith("ibc/")) {
-    return macroCoin;
+  if (!asset && displayCoin.denom.toLowerCase().startsWith("ibc/")) {
+    return displayCoin;
   }
 
-  assert(asset, `An asset with the given symbol ${macroCoin.denom} was not found`);
+  assert(asset, `An asset with the given symbol ${displayCoin.denom} was not found`);
 
   const macroUnit = asset.denom_units.find(
     (currentUnit) => lowerCaseDenom === currentUnit.denom.toLowerCase(),
@@ -33,9 +33,12 @@ const macroCoinToMicroCoin = (macroCoin: Coin, assets: readonly RegistryAsset[])
   assert(baseUnit, `A base unit with exponent = 0 was not found`);
 
   const denom = baseUnit.denom;
-  const amount = Decimal.fromUserInput(macroCoin.amount.trim() || "0", macroUnit.exponent).atomics;
+  const amount = Decimal.fromUserInput(
+    displayCoin.amount.trim() || "0",
+    macroUnit.exponent,
+  ).atomics;
 
   return { denom, amount };
 };
 
-export { macroCoinToMicroCoin };
+export { displayCoinToBaseCoin };


### PR DESCRIPTION
Closes #180.
Closes #183.
Closes #191.
Closes #192.

#180 was because of missing validation.
#183 and #192 because we didn't account for IBC tokens not disclosed on the chain-registry.
#191 because if funds/amount was an array, we sent an empty coin instead of an empty array.