### PR TITLE
Autofill IBC MsgTransfer channel

### DIFF
--- a/components/forms/CreateTxForm/MsgForm/MsgTransferForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgTransferForm.tsx
@@ -121,6 +121,25 @@ const MsgTransferForm = ({ senderAddress, setMsgGetter, deleteMsg }: MsgTransfer
     setMsgGetter({ isMsgValid, msg });
   }, [chain.chainId, senderAddress, setMsgGetter, trimmedInputs]);
 
+  useEffect(() => {
+    if (!denom || !denom.startsWith("ibc/")) {
+      return;
+    }
+
+    const foundDenom = chain.assets.find((asset) => asset.base === denom);
+    if (!foundDenom) {
+      return;
+    }
+
+    const trace = foundDenom.traces?.[0];
+    if (!trace) {
+      return;
+    }
+
+    setSourcePort(trace.chain?.path?.split("/")[0] || "transfer");
+    setSourceChannel(trace.chain?.channel_id || "");
+  }, [chain.assets, denom]);
+
   return (
     <StackableContainer lessPadding lessMargin>
       <button className="remove" onClick={() => deleteMsg()}>

--- a/components/forms/CreateTxForm/MsgForm/MsgTransferForm.tsx
+++ b/components/forms/CreateTxForm/MsgForm/MsgTransferForm.tsx
@@ -136,7 +136,7 @@ const MsgTransferForm = ({ senderAddress, setMsgGetter, deleteMsg }: MsgTransfer
       return;
     }
 
-    setSourcePort(trace.chain?.path?.split("/")[0] || "transfer");
+    setSourcePort(trace.chain?.path?.split("/")?.[0] || "transfer");
     setSourceChannel(trace.chain?.channel_id || "");
   }, [chain.assets, denom]);
 

--- a/types/chainRegistry.ts
+++ b/types/chainRegistry.ts
@@ -79,6 +79,19 @@ export interface RegistryAssetDenomUnit {
   readonly aliases?: readonly string[];
 }
 
+export interface AssetTrace {
+  readonly type?: "string";
+  readonly chain?: {
+    readonly channel_id?: string;
+    readonly path?: string;
+  };
+  readonly counterparty?: {
+    readonly chain_name?: string;
+    readonly base_denom?: string;
+    readonly channel_id?: string;
+  };
+}
+
 /**
  * See https://github.com/cosmos/chain-registry/blob/1e9ecde770951cab90f0853a624411d79af90b83/provenance/assetlist.json#L5-L28
  */
@@ -94,4 +107,5 @@ export interface RegistryAsset {
     readonly svg: string;
   };
   readonly coingecko_id?: string;
+  readonly traces?: readonly AssetTrace[];
 }


### PR DESCRIPTION
Closes #174.

Autofills port and channel if denom is found on assets. Dropdown not implemented as it would be very confusing because of the number of assets there. Copy-pasting the long IBC denom will be a more probable use-case.