### PR TITLE
Load amino msg data

### DIFF
--- a/components/forms/CreateTxForm/index.tsx
+++ b/components/forms/CreateTxForm/index.tsx
@@ -1,6 +1,9 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { getMsgRegistry } from "@/lib/msg";
 
 export default function CreateTxForm() {
+  console.log({ msgRegistry: getMsgRegistry() });
+
   return (
     <Card>
       <CardHeader>

--- a/components/forms/TransactionSigning.tsx
+++ b/components/forms/TransactionSigning.tsx
@@ -1,19 +1,15 @@
 import { DbSignatureObj, DbSignatureObjDraft, DbTransactionParsedDataJson } from "@/graphql";
 import { createDbSignature } from "@/lib/api";
 import { getKeplrAminoSigner, getKeplrKey, useKeplrReconnect } from "@/lib/keplr";
+import { aminoConverters } from "@/lib/msg";
 import { toastError, toastSuccess } from "@/lib/utils";
 import { LoadingStates, SigningStatus } from "@/types/signing";
 import { MultisigThresholdPubkey, makeCosmoshubPath } from "@cosmjs/amino";
-import { createWasmAminoConverters, wasmTypes } from "@cosmjs/cosmwasm-stargate";
+import { wasmTypes } from "@cosmjs/cosmwasm-stargate";
 import { toBase64 } from "@cosmjs/encoding";
 import { LedgerSigner } from "@cosmjs/ledger-amino";
 import { OfflineSigner, Registry } from "@cosmjs/proto-signing";
-import {
-  AminoTypes,
-  SigningStargateClient,
-  createDefaultAminoConverters,
-  defaultRegistryTypes,
-} from "@cosmjs/stargate";
+import { AminoTypes, SigningStargateClient, defaultRegistryTypes } from "@cosmjs/stargate";
 import { assert } from "@cosmjs/utils";
 import { Key } from "@keplr-wallet/types";
 import TransportWebUSB from "@ledgerhq/hw-transport-webusb";
@@ -146,10 +142,7 @@ const TransactionSigning = (props: TransactionSigningProps) => {
       assert(signerAddress, "Missing signer address");
       const signingClient = await SigningStargateClient.offline(offlineSigner, {
         registry: new Registry([...defaultRegistryTypes, ...wasmTypes]),
-        aminoTypes: new AminoTypes({
-          ...createDefaultAminoConverters(),
-          ...createWasmAminoConverters(),
-        }),
+        aminoTypes: new AminoTypes(aminoConverters),
       });
 
       const signerData = {

--- a/lib/msg.ts
+++ b/lib/msg.ts
@@ -1,0 +1,44 @@
+import { txCosmJsTypes } from "@/types/cosmjs-types";
+import { createWasmAminoConverters } from "@cosmjs/cosmwasm-stargate";
+import { createDefaultAminoConverters } from "@cosmjs/stargate";
+
+export const aminoConverters = {
+  ...createDefaultAminoConverters(),
+  ...createWasmAminoConverters(),
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const msgRegistry: Record<string, any> = {};
+
+const codecs = txCosmJsTypes
+  .filter(
+    (type) =>
+      typeof type === "object" &&
+      "typeUrl" in type &&
+      "encode" in type &&
+      "decode" in type &&
+      "fromJSON" in type &&
+      "toJSON" in type &&
+      "fromPartial" in type,
+  )
+  .filter((type) => Object.keys(aminoConverters).includes(type.typeUrl));
+
+for (const codec of codecs) {
+  const splitTypeUrl = codec.typeUrl.split(".");
+  const name = splitTypeUrl[splitTypeUrl.length - 1];
+  const category = splitTypeUrl[0] === "/cosmos" ? splitTypeUrl[1] : splitTypeUrl[0].slice(1);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const emptyMsg = (codec as any).fromPartial({});
+
+  msgRegistry[codec.typeUrl] = {
+    typeUrl: codec.typeUrl,
+    category,
+    name,
+    fields: Object.keys(emptyMsg),
+    emptyMsg,
+    codec,
+  };
+}
+
+export const getMsgRegistry = () => msgRegistry;

--- a/types/cosmjs-types.ts
+++ b/types/cosmjs-types.ts
@@ -1,0 +1,21 @@
+import * as CosmjsTypesAuthz from "cosmjs-types/cosmos/authz/v1beta1/tx";
+import * as CosmjsTypesBank from "cosmjs-types/cosmos/bank/v1beta1/tx";
+import * as CosmjsTypesDistribution from "cosmjs-types/cosmos/distribution/v1beta1/tx";
+import * as CosmjsTypesFeegrant from "cosmjs-types/cosmos/feegrant/v1beta1/tx";
+import * as CosmjsTypesGov from "cosmjs-types/cosmos/gov/v1beta1/tx";
+import * as CosmjsTypesStaking from "cosmjs-types/cosmos/staking/v1beta1/tx";
+import * as CosmjsTypesVesting from "cosmjs-types/cosmos/vesting/v1beta1/tx";
+import * as CosmjsTypesCosmWasm from "cosmjs-types/cosmwasm/wasm/v1/tx";
+import * as CosmjsTypesIbcTransfer from "cosmjs-types/ibc/applications/transfer/v1/tx";
+
+export const txCosmJsTypes = Object.values({
+  ...CosmjsTypesAuthz,
+  ...CosmjsTypesBank,
+  ...CosmjsTypesDistribution,
+  ...CosmjsTypesFeegrant,
+  ...CosmjsTypesGov,
+  ...CosmjsTypesStaking,
+  ...CosmjsTypesVesting,
+  ...CosmjsTypesIbcTransfer,
+  ...CosmjsTypesCosmWasm,
+});


### PR DESCRIPTION
Part of #234.

Builds a msg registry with typeUrl, category, name, fields, emptyMsg, and codec (per typeUrl). Only for msgs that support amino encoding.